### PR TITLE
Create table of contents for home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,25 @@
 
 		Welcome to the Graphics Programming's Discord knowledge base. This resource is used to collect other resources into a centralized location.
 
+		## Table of Contents
+		[APIs](#apis)
+		* [Direct3D](#direct3d)
+		* [Metal](#metal)
+		* [OpenGL](#opengl)
+		* [Vulkan](#vulkan)
+		[Shader Programming](#shader-programming)
+		* [Guides](#guides)
+		[Techniques](#techniques)
+		* [Render Graphs](#render-graphs)
+		* [Tonemapping](#tonemapping)
+
 		## APIs
 
 		### Direct3D
 		* [bell0bytes Blog - DirectX Fundamentals](https://bell0bytes.eu/direct-x-com/)
 		* [3DGEP Blog - DirectX Tutorials](https://www.3dgep.com/category/graphics-programming/directx/)
 		* [DirectX Specification](https://microsoft.github.io/DirectX-Specs/)
-		
+
 		### Metal
 		* [Metal Specification](https://developer.apple.com/documentation/metal)
 
@@ -37,6 +49,11 @@
 		* [Fundamentals of the Vulkan Graphics API: Why Rendering a Triangle is Complicated](https://liamhinzman.com/blog/vulkan-fundamentals)
 		* [Vulkan 1.2.141 Specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html)
 		* [Vulkan Tutorial](https://vulkan-tutorial.com/)
+
+		## Shader Programming
+
+		### Guides
+		* [3D Game Shaders for Beginners](https://github.com/lettier/3d-game-shaders-for-beginners)
 		
 		## Techniques
 	  
@@ -52,11 +69,6 @@
 		* [Filmic Worlds Blog](http://filmicworlds.com/blog/)
 		* [High Dynamic Range Imaging Book](https://www.cl.cam.ac.uk/~rkm38/pdfs/mantiuk15hdri.pdf)
 		* [Tone Mapping (slides)](https://www.cl.cam.ac.uk/~rkm38/pdfs/tone_mapping.pdf)
-		
-		## Shader Programming
-		
-		### Guides
-		* [3D Game Shaders for Beginners](https://github.com/lettier/3d-game-shaders-for-beginners)
 
 	</code>
 


### PR DESCRIPTION
Table of contents at the top of the home page for easy access to headings.