### PR TITLE
Add link to SIGGRAPH 2020 Vulkan slides

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -47,6 +47,7 @@
 		* [Fundamentals of the Vulkan Graphics API: Why Rendering a Triangle is Complicated](https://liamhinzman.com/blog/vulkan-fundamentals)
 		* [Vulkan 1.2.141 Specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html)
 		* [Vulkan Tutorial](https://vulkan-tutorial.com/)
+		* [SIGGRAPH 2020 slides and notes on Vulkan](http://web.engr.oregonstate.edu/~mjb/vulkan/)
 
 		# Shader Programming
 

--- a/resources/index.html
+++ b/resources/index.html
@@ -45,9 +45,9 @@
 
 		## Vulkan
 		* [Fundamentals of the Vulkan Graphics API: Why Rendering a Triangle is Complicated](https://liamhinzman.com/blog/vulkan-fundamentals)
+		* [SIGGRAPH 2020 slides and notes on Vulkan](http://web.engr.oregonstate.edu/~mjb/vulkan/)
 		* [Vulkan 1.2.141 Specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html)
 		* [Vulkan Tutorial](https://vulkan-tutorial.com/)
-		* [SIGGRAPH 2020 slides and notes on Vulkan](http://web.engr.oregonstate.edu/~mjb/vulkan/)
 
 		# Shader Programming
 


### PR DESCRIPTION
I found [this page](http://web.engr.oregonstate.edu/~mjb/vulkan/) which has a bunch of slides and notes on Vulkan for SIGGRAPH 2020. I added it to the resources page, so merging should be enough to add it.